### PR TITLE
Send message version header with all outbound messages

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -106,6 +106,11 @@ Client.prototype.awaitMethodBulk = function(method, paramList, options) {
 
 Client.prototype.invokeMethod = function(method, params, options) {
 
+  options = options || {};
+  options.headers = options.headers || {};
+
+  options.headers['harmonia-message'] = '1.0';
+
   var content = new Buffer(JSON.stringify({
     method : method,
     params : params

--- a/lib/Response.js
+++ b/lib/Response.js
@@ -40,9 +40,12 @@ Response.prototype.getResult = function() {
 };
 
 Response.prototype.toMessage = function() {
+  var headers = this.headers || {};
+  headers['harmonia-message'] = '1.0';
+
   return new Message({
     properties : this.properties,
-    headers : this.headers || {},
+    headers : headers,
     content : {
       result : this.result
     }


### PR DESCRIPTION
In preparation for a 2.0,  I want to start versioning messages both internally and externally so servers know how to handle the payload, even if we decide to change the format in the future. This covers the internal versioning portion.

**Warning:** using the new dead letter exchange with existing queues/method names will cause your app to fail when it launches, due to the assertion that the queue exists with the same parameters. You should shutdown your app and delete any existing queues before upgrading.